### PR TITLE
Fix displayed duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "pev2",
-  "version": "1.12.1",
+  "name": "duckdb-explain-visualizer",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "pev2",
-      "version": "1.12.1",
+      "name": "duckdb-explain-visualizer",
+      "version": "1.0.0",
       "license": "PostgreSQL license",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
@@ -20,7 +20,6 @@
         "highlight.js": "^11.7.0",
         "humanize-duration": "^3.28.0",
         "lodash": "^4.17.21",
-        "pev2": "^1.12.1",
         "sass": "^1.58.0",
         "splitpanes": "^3.1.5",
         "vue": "^3.2.45",
@@ -6935,30 +6934,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pev2": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pev2/-/pev2-1.12.1.tgz",
-      "integrity": "sha512-ZnevxICC7Z04vOk/rif3KylQH9SQ8yxhEyxTbGCHmDNgeKSkoV4qG4XfXmzfy+zApbTvmsSbuclS66h/222UZA==",
-      "license": "PostgreSQL license",
-      "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^6.5.2",
-        "@fortawesome/free-solid-svg-icons": "^6.5.2",
-        "@fortawesome/vue-fontawesome": "^3.0.6",
-        "bootstrap": "^5.3.2",
-        "clarinet": "^0.12.5",
-        "d3": "^7.8.2",
-        "d3-flextree": "^2.1.2",
-        "emitter": "^0.0.2",
-        "highlight.js": "^11.7.0",
-        "humanize-duration": "^3.28.0",
-        "lodash": "^4.17.21",
-        "sass": "^1.58.0",
-        "splitpanes": "^3.1.5",
-        "vue": "^3.2.45",
-        "vue-clipboard3": "^2.0.0",
-        "vue-tippy": "^6.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -13925,29 +13900,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
-    },
-    "pev2": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/pev2/-/pev2-1.12.1.tgz",
-      "integrity": "sha512-ZnevxICC7Z04vOk/rif3KylQH9SQ8yxhEyxTbGCHmDNgeKSkoV4qG4XfXmzfy+zApbTvmsSbuclS66h/222UZA==",
-      "requires": {
-        "@fortawesome/fontawesome-svg-core": "^6.5.2",
-        "@fortawesome/free-solid-svg-icons": "^6.5.2",
-        "@fortawesome/vue-fontawesome": "^3.0.6",
-        "bootstrap": "^5.3.2",
-        "clarinet": "^0.12.5",
-        "d3": "^7.8.2",
-        "d3-flextree": "^2.1.2",
-        "emitter": "^0.0.2",
-        "highlight.js": "^11.7.0",
-        "humanize-duration": "^3.28.0",
-        "lodash": "^4.17.21",
-        "sass": "^1.58.0",
-        "splitpanes": "^3.1.5",
-        "vue": "^3.2.45",
-        "vue-clipboard3": "^2.0.0",
-        "vue-tippy": "^6.0.0"
-      }
     },
     "picocolors": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "highlight.js": "^11.7.0",
     "humanize-duration": "^3.28.0",
     "lodash": "^4.17.21",
-    "duckdb-explain-visualizer": "^1.0.0",
     "sass": "^1.58.0",
     "splitpanes": "^3.1.5",
     "vue": "^3.2.45",

--- a/src/components/GridRow.vue
+++ b/src/components/GridRow.vue
@@ -93,7 +93,7 @@ function formattedProp(propName: keyof typeof NodeProp) {
           v-if="durationClass"
         ></severity-bullet>
         <span class="flex-grow-1">
-          {{ Math.round(node[NodeProp.ACTUAL_TIME] ?? 0).toLocaleString() }}
+          {{ duration(node[NodeProp.ACTUAL_TIME]) }}
         </span>
       </div>
       <div v-if="showDetails" class="small text-body-secondary">

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -14,7 +14,7 @@ export function duration(value: number | undefined): string {
     return "N/A"
   }
   const result: string[] = []
-  let denominator: number = 1000 * 60 * 60 * 24
+  let denominator: number = 60 * 60 * 24
   const days = Math.floor(value / denominator)
   if (days) {
     result.push(days + "d")
@@ -32,14 +32,13 @@ export function duration(value: number | undefined): string {
     result.push(minutes + "m")
   }
   remainder = remainder % denominator
-  denominator /= 60
-  const seconds = Math.floor(remainder / denominator)
-  if (seconds) {
-    result.push(seconds + "s")
+  if (remainder >= 1) {
+    const seconds = parseFloat(remainder.toFixed(2))
+    result.push(seconds.toLocaleString() + "s")
+  } else {
+    const milliseconds = parseFloat((remainder * 1000).toFixed(2))
+    result.push(milliseconds.toLocaleString() + "ms")
   }
-  remainder = remainder % denominator
-  const milliseconds = parseFloat(remainder.toPrecision(3))
-  result.push(milliseconds.toLocaleString() + "ms")
 
   return result.slice(0, 2).join(" ")
 }


### PR DESCRIPTION
The DuckDB profiler reports timings in seconds, but prior to this change, the duration was calculated assuming the input was in milliseconds