### PR TITLE
Update extra_info relation name for duckdb v1.2

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -60,7 +60,7 @@ export enum NodeProp {
 
   // EXTRA INFO KEYS
   EXTRA_INFO = "extra_info", // Unique operator metrics
-  RELATION_NAME = "Text",
+  RELATION_NAME = "Table",
   PROJECTIONS = "Projections",
   ESTIMATED_ROWS = "Estimated Cardinality",
   AGGREGATES = "Aggregates",


### PR DESCRIPTION
duckdb v1.2 changes the key in `extra_info` from `Text` to `Table`